### PR TITLE
Add a missing method to change the international font/encoding

### DIFF
--- a/zpl/label.py
+++ b/zpl/label.py
@@ -97,6 +97,29 @@ class Label:
         assert re.match(r'[A-Z0-9]', font), "invalid font"
         self.code += "^CF%c,%i,%i" % (font, height*self.dpmm, width*self.dpmm)
 
+    def change_international_font(self, character_set=28, remaps=[]):
+        """
+        change the international font/encoding, that enables you to call
+        up the international character set you want to use for printing
+
+        "remaps" arg is a list of tuples with the number of the source
+        character and the substitute character destination.
+        """
+        ci_code = '^CI%i' % (character_set)
+
+        charset_regex_range = "(3[0-6]|[12]?[0-9])"
+        range_regex = "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])"
+        ci_regex = r"^\^CI%s((\,%s,%s){1,})*$" % (
+            charset_regex_range, range_regex, range_regex)
+
+        for src, dest in remaps:
+            ci_code += ',%i,%i' % (src, dest)
+
+        print(ci_code)
+
+        assert re.match(ci_regex, ci_code), "invalid character set"
+        self.code += ci_code
+
     def _convert_image(self, image, width, height, compression_type='A'):
         '''
         converts *image* (of type PIL.Image) to a ZPL2 format

--- a/zpl/label.py
+++ b/zpl/label.py
@@ -115,8 +115,6 @@ class Label:
         for src, dest in remaps:
             ci_code += ',%i,%i' % (src, dest)
 
-        print(ci_code)
-
         assert re.match(ci_regex, ci_code), "invalid character set"
         self.code += ci_code
 


### PR DESCRIPTION
Hey guys, what's up? I've been using this awesome library in my work and it's a nice approach to mount .zpl files with Python, but I've been finding some difficulties to set the utf-8 encoding of the .zpl file... 

Words like "São Paulo" and "João" will output some strange words on the printed document.
I purpose to add a new method to set this encoding using the **^CI** command.

Some doubts about the ^CI command, check ^CI the topic in [zebra manual](https://www.zebra.com/content/dam/zebra/manuals/printers/common/programming/zpl-zbi2-pm-en.pdf).

Thanks!