### PR TITLE
Use nearest rather than bicubic when resizing to avoid corrupting barcodes in images.

### DIFF
--- a/zpl/label.py
+++ b/zpl/label.py
@@ -139,7 +139,7 @@ class Label:
 
         returns data
         '''
-        image = image.resize((int(width*self.dpmm), int(height*self.dpmm)))
+        image = image.resize((int(width*self.dpmm), int(height*self.dpmm)), PIL.Image.NEAREST)
         # invert, otherwise we get reversed B/W
         # https://stackoverflow.com/a/38378828
         image = PIL.ImageOps.invert(image.convert('L')).convert('1')


### PR DESCRIPTION
Use nearest rather than bicubic when resizing to avoid corrupting barcodes in images.