### PR TITLE
Added PW, LL and zpl_raw

### DIFF
--- a/zpl/label.py
+++ b/zpl/label.py
@@ -37,6 +37,8 @@ class Label:
         self.dpmm = dpmm
 
         self.code = "^XA"
+        self.code += "^PW%i" % (width*dpmm)
+        self.code += "^LL%i" % (height*dpmm)
 
     def labelhome(self, x, y, justification=None):
         """
@@ -70,6 +72,12 @@ class Label:
         
         assert (value >= 0 and value <= 30), "The value must be between 0 and 30"
         self.code += "~SD" + str(value)
+
+    def zpl_raw(self, commands):
+        """
+        Send raw commands to the printer
+        """
+        self.code += commands
 
     def textblock(self, width, justification='C', lines=1):
         """


### PR DESCRIPTION
I added the PW and LL commands to the ZPL init. Especially the PW is important when the printer settings have been changed by another job. For the dame reason I added a zpl_raw command that allows to reset settings like ^PO or ^PM. 