### PR TITLE
Use raw string for justification as Python >3.12 will throw errors

### DIFF
--- a/zpl/label.py
+++ b/zpl/label.py
@@ -117,7 +117,7 @@ class Label:
             self.code += "^FD%s" % text
         
         if justification == 'C':
-            self.code += "\&"
+            self.code += r"\&"
 
     def set_default_font(self, height, width, font='0'):
         """


### PR DESCRIPTION
According to https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes it is intended to use raw strings when they include the backslash character within the string. This is also the case for justification of label content which throws an error in Python 3.12 and above.