### PR TITLE
feat: Compression and conversion

### DIFF
--- a/zpl/label.py
+++ b/zpl/label.py
@@ -7,10 +7,10 @@ from __future__ import print_function
 from PIL import Image
 import re
 import PIL.ImageOps
-import sys
 import math
-import webbrowser
 import os.path
+
+from zpl.utils import compress_zpl_data
 try:
     from urllib.request import urlopen
 except ImportError:
@@ -167,14 +167,7 @@ class Label:
         # https://stackoverflow.com/a/38378828
         image = PIL.ImageOps.invert(image.convert('L')).convert('1')
 
-        if compression_type == "A":
-            # return image.tobytes().encode('hex').upper()
-            return image.tobytes().hex().upper()
-        # TODO this is not working
-        #elif compression_type == "B":
-        #    return image.tostring()
-        else:
-            raise Exception("unsupported compression type")
+        return compress_zpl_data(image.tobytes().hex().upper())
 
     def upload_graphic(self, name, image, width, height=0):
         """
@@ -235,7 +228,7 @@ class Label:
         """
         assert color in 'BW', "invalid color"
         assert rounding <= 8, "invalid rounding"
-        self.code += "^GB%i,%i,%i,%c,%i" % (width, height, thickness, color, rounding)
+        self.code += "^GB%i,%i,%i,%c,%i" % (width*self.dpmm, height*self.dpmm, thickness*self.dpmm, color, rounding)
 
     def draw_ellipse(self, width, height, thickness=1, color='B'):
         """
@@ -245,7 +238,7 @@ class Label:
         *color* can be either "B" or "W"
         """
         assert color in 'BW', "invalid color"
-        self.code += "^GE%i,%i,%i,%c" % (width, height, thickness, color)
+        self.code += "^GE%i,%i,%i,%c" % (width*self.dpmm, height*self.dpmm, thickness*self.dpmm, color)
 
     def print_graphic(self, name, scale_x=1, scale_y=1):
         """

--- a/zpl/utils.py
+++ b/zpl/utils.py
@@ -1,0 +1,116 @@
+
+
+# Zebra-specific run-length encoding mapping,
+# where run lengths (1–400) are encoded using characters 'G' to 'z'.
+# See Zebra ZPL II Programming Guide for details.
+ZPL_COMPRESS_MAP = {
+    1: "G",
+    2: "H",
+    3: "I",
+    4: "J",
+    5: "K",
+    6: "L",
+    7: "M",
+    8: "N",
+    9: "O",
+    10: "P",
+    11: "Q",
+    12: "R",
+    13: "S",
+    14: "T",
+    15: "U",
+    16: "V",
+    17: "W",
+    18: "X",
+    19: "Y",
+    20: "g",
+    40: "h",
+    60: "i",
+    80: "j",
+    100: "k",
+    120: "l",
+    140: "m",
+    160: "n",
+    180: "o",
+    200: "p",
+    220: "q",
+    240: "r",
+    260: "s",
+    280: "t",
+    300: "u",
+    320: "v",
+    340: "w",
+    360: "x",
+    380: "y",
+    400: "z",
+}
+
+ZPL_COMPRESS_COUNTS = list(ZPL_COMPRESS_MAP.keys())
+ZPL_COMPRESS_COUNTS.sort(reverse=True)
+
+
+def _compress_char(count: int, char: str) -> str:
+    data = ""
+    local_count_glyph = ""
+
+    while count > 0:
+        local_count = 0
+        for counts in ZPL_COMPRESS_COUNTS:
+            if counts > count:
+                continue
+            count -= counts
+            local_count_glyph += ZPL_COMPRESS_MAP[counts]
+            local_count += counts
+            break
+
+    if local_count_glyph == "G":
+        data += f"{char}"
+    else:
+        data += f"{local_count_glyph}{char}"
+    return data
+
+
+def compress_zpl_data(zpl_data: str) -> str:
+    """
+    Compresses ZPL (Zebra Programming Language) data using run-length encoding.
+
+    This function applies ZPL-specific compression techniques to reduce the size
+    of label definitions before sending them to the printer. It is particularly
+    useful for compressing large graphic (~^GFA) fields or repeated character sequences.
+
+    Parameters
+    ----------
+    zpl_data : str
+        The raw ZPL string to be compressed.
+
+    Returns
+    -------
+    str
+        The compressed ZPL string.
+
+    Notes
+    -----
+    - This function does not validate whether the input is valid ZPL.
+    - It is intended for use with printable ZPL data such as graphics or large text fields.
+
+    Examples
+    --------
+    >>> raw_zpl = '^GFA,...long hex string...^FS'
+    >>> compressed = compress_zpl(raw_zpl)
+    >>> print(compressed)
+    '^GFA,...compressed hex string...^FS'
+    """
+
+    zipped_data = ""
+    i = 0
+    while i < len(zpl_data):
+        cnt = 1
+        next = zpl_data[i]
+        for j in range(i + 1, len(zpl_data)):
+            if zpl_data[j] == next:
+                cnt += 1
+            else:
+                break
+        zipped_data += _compress_char(cnt, next)
+        i += cnt
+    return zipped_data


### PR DESCRIPTION
- Implements a utility to compress ZPL data, especially useful for optimizing large image or text blocks (e.g., ^GFA fields). Uses Zebra's run-length encoding character mapping as specified in the ZPL II programming guide.
- Fixes the mm conversion in draw_box
- Fixes the mm conversion in draw_elipse
- Removes some unnecessary imports